### PR TITLE
docs: document player rank endpoint

### DIFF
--- a/100_objects/300_player.md
+++ b/100_objects/300_player.md
@@ -4,7 +4,7 @@
 
 Each player on the list is represented by a `Player` object. The following invariant holds true for any player object:
 
-- If the player is banned, they do not have any approved or submitted records on the list
+* If the player is banned, they do not have any approved or submitted records on the list
 
 Note that it is not possible to retrieve a player's demonlist score via the API. You can calculate it yourself based on the `records` list
 
@@ -29,6 +29,19 @@ When retrieving players via [`GET /players/`](/documentation/players/#get-player
 | banned      | boolean                     | Value indicating whether the player is banned |
 | nationality | [Nationality](#nationality) | The player's nationality, if set              |
 | score       | float                       | The player's stats viewer score               |
+
+## Ranked Form
+
+Same as above, but with the player's rank.
+
+| Field       | Type                        | Description                                                                                                                                                                                   |
+| ----------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id          | integer                     | The player's id                                                                                                                                                                               |
+| name        | string                      | The player's name                                                                                                                                                                             |
+| banned      | boolean                     | Value indicating whether the player is banned                                                                                                                                                 |
+| score       | float                       | The player's stats viewer score                                                                                                                                                               |
+| nationality | [Nationality](#nationality) | The player's nationality, if set                                                                                                                                                              |
+| rank        | integer                     | The player's rank. Multiple players can have the same rank, if they have the same score. The ranking is not dense, meaning multiple player having the same rank causes a hole in the ranking. |
 
 ## Full Form
 
@@ -70,6 +83,22 @@ The listed record objects do not contain the current player embedded into the `p
     "country_code": "AD"
   },
   "score": 0
+}
+```
+
+### Ranked Form
+
+```json
+{
+  "id": 4,
+  "name": "Pennutoh",
+  "banned": false,
+  "nationality": {
+    "nation": "Andorra",
+    "country_code": "AD"
+  },
+  "score": 0,
+  "rank": 1
 }
 ```
 

--- a/400_players/050_get_ranking.md
+++ b/400_players/050_get_ranking.md
@@ -10,18 +10,7 @@ This endpoint supports [pagination and filtering](/documentation/#pagination) vi
 on the additional request and response fields headers.
 </div>
 
-This endpoint is used by the stats viewer. It is a more limited (and slower) version of [`/players/`](#get-players). It should only be used if the additional information (player scores and ranking) is actually required.
-
-Additionally, the endpoint uses its own special format for [Player](/documentation/objects#player) objects, which is a modified version of the listed form.
-
-| Field       | Type                        | Description                                                                                                                                                                                   |
-| ----------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id          | integer                     | The player's id                                                                                                                                                                               |
-| name        | string                      | The player's name                                                                                                                                                                             |
-| banned      | boolean                     | Value indicating whether the player is banned                                                                                                                                                 |
-| nationality | [Nationality](#nationality) | The player's nationality, if set                                                                                                                                                              |
-| rank        | integer                     | The player's rank. Multiple players can have the same rank, if they have the same score. The ranking is not dense, meaning multiple player having the same rank causes a hole in the ranking. |
-| score       | double                      | The player's score                                                                                                                                                                            |
+This endpoint is used by the stats viewer. It is a more limited (and slower) version of `/players/`. It should only be used if the additional information (player scores and ranking) is actually required.
 
 ### Filtering:
 
@@ -41,9 +30,9 @@ Since none of the fields have the characteristics required of a pagination field
 | ------------ | ------------------ |
 | Content-Type | `application/json` |
 
-| Field | Type               | Description                                          |
-| ----- | ------------------ | ---------------------------------------------------- |
-| -     | List[RankedPlayer] | A list of players (see above for the special format) |
+| Field | Type               | Description                                         |
+| ----- | ------------------ | --------------------------------------------------- |
+| -     | List[[RankedPlayer](#player)] | A list of players, including their ranks |
 
 ### Example request:
 

--- a/400_players/100_get_player.md
+++ b/400_players/100_get_player.md
@@ -4,14 +4,14 @@
 
 ## `GET`{.verb} `/players/` `player_id`{.param} `/`
 
-Retrieves detailed information about the player with id `player_id`
+Retrieves information about the player with id `player_id`
 
 ### Request:
 
-| Header        | Expected Value                                                                                                                                                                                              | Optional |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| If-Match      | Conditional request header. If the etag value of the requested data matches any of the here provided values, the data is returned as requested. Otherwise a `412 PRECONDITION FAILED` response is generated | true     |
-| If-None-Match | Conditional request header. If the etag value of the requested data does not match any of the here provided values, if it returned as requested. Otherwise, a `304 NOT MODIFED` response is generated       | true     |
+| Header | Expected Value | Optional |
+|----|----|----|
+| If-Match | Conditional request header. If the etag value of the requested data matches any of the here provided values, the data is returned as requested. Otherwise a `412 PRECONDITION FAILED` response is generated | true |
+| If-None-Match | Conditional request header. If the etag value of the requested data does not match any of the here provided values, if it returned as requested. Otherwise, a `304 NOT MODIFED` response is generated | true |
 
 ### Response: `200 OK`
 
@@ -20,9 +20,9 @@ Retrieves detailed information about the player with id `player_id`
 | Content-Type | `application/json`                       |
 | ETag         | unsigned 64 bit  hash of the player object |
 
-| Field | Type                                     | Description                 |
-| ----- | ---------------------------------------- | --------------------------- |
-| data  | [Player](/documentation/objects/#player) | The requested player object |
+| Field | Type | Description |
+|----|----|----|
+| data | [Player](/documentation/objects/#player) | The requested player object |
 
 ### Response: `304 NOT MODIFIED`
 

--- a/400_players/100_get_player_rank.md
+++ b/400_players/100_get_player_rank.md
@@ -1,0 +1,48 @@
+<div class='panel fade js-scroll-anim' data-anim='fade'>
+
+# Player ranking retrieval.{id=get-player-ranking}
+
+## `GET`{.verb} `/players/ranking/` `player_id`{.param} `/`
+
+Retrieves detailed information about the player with id `player_id`
+
+### Request:
+
+| Header        | Expected Value                                                                                                                                                                                              | Optional |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| If-Match      | Conditional request header. If the etag value of the requested data matches any of the here provided values, the data is returned as requested. Otherwise a `412 PRECONDITION FAILED` response is generated | true     |
+| If-None-Match | Conditional request header. If the etag value of the requested data does not match any of the here provided values, if it returned as requested. Otherwise, a `304 NOT MODIFED` response is generated       | true     |
+
+### Response: `200 OK`
+
+| Header       | Value                                     |
+| ------------ | ----------------------------------------- |
+| Content-Type | `application/json`                        |
+| ETag         | unsigned 64 bit hash of the player object |
+
+| Field | Type                    | Description                 |
+| ----- | ----------------------- | --------------------------- |
+| data  | [RankedPlayer](#player) | The requested player object |
+
+### Response: `304 NOT MODIFIED`
+
+Returned if the `If-None-Match` header is set, and the etag for the player object matches one of the set values.
+
+| Header | Value                                      |
+| ------ | ------------------------------------------ |
+| ETag   | unsigned 64 bit  hash of the player object |
+
+### Errors:
+
+| Status code | Error code | Description                             |
+| ----------- | ---------- | --------------------------------------- |
+| 404         | 40401      | No player with id `player_id` was found |
+
+### Example request:
+
+```json
+GET /api/v1/players/ranking/1/
+Accept: application/json
+```
+
+</div>

--- a/400_players/150_get_player_rank.md
+++ b/400_players/150_get_player_rank.md
@@ -4,7 +4,7 @@
 
 ## `GET`{.verb} `/players/ranking/` `player_id`{.param} `/`
 
-Retrieves detailed information about the player with id `player_id`
+Retrieves detailed information about the player with id `player_id`, including the player's rank
 
 ### Request:
 


### PR DESCRIPTION
adds documentation for `api/v1/players/ranking/{id}`

also my rich markdown editor extension is like formatting everything I open??? and it messes up all the table structures?? lol??